### PR TITLE
Fix bug where we were modifying the underlying samples list

### DIFF
--- a/vcf_annotation_tools/vcf_readcount_annotator.py
+++ b/vcf_annotation_tools/vcf_readcount_annotator.py
@@ -238,7 +238,7 @@ def main(args_input = sys.argv[1:]):
         #samples need to be changed from a single number to an array or
         #else the writer will throw an error
         if is_multi_sample:
-            other_samples = vcf_reader.header.samples.names
+            other_samples = vcf_reader.header.samples.names.copy()
             other_samples.remove(sample_name)
             for sample in other_samples:
                 sample_data = entry.call_for_sample[sample].data


### PR DESCRIPTION
We need to make a copy of vcf_reader.header.samples.names. Otherwise
we are modifying the underlying list when we remove the sample of
interest on the subsequent line which leads to problem next time we
want to access the genotype for the sample of interest.