### PR TITLE
New tool to add new samples with genotype fields to a VCF

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
             "vcf-expression-annotator = vatools.vcf_expression_annotator:main",
             "vcf-readcount-annotator = vatools.vcf_readcount_annotator:main",
             "vcf-info-annotator = vatools.vcf_info_annotator:main",
+            "vcf-genotype-annotator = vatools.vcf_genotype_annotator:main",
             "vep-annotation-reporter = vatools.vep_annotation_reporter:main",
         ]
     },

--- a/tests/test_data/input.no_sample.vcf
+++ b/tests/test_data/input.no_sample.vcf
@@ -1,0 +1,3 @@
+##fileformat=VCFv4.2
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+22	18644673	.	C	T	.	.	.

--- a/tests/test_data/no_sample.genotype.vcf
+++ b/tests/test_data/no_sample.genotype.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TUMOR
+22	18644673	.	C	T	.	.	.	GT	0/1

--- a/tests/test_data/single_sample.genotype.vcf
+++ b/tests/test_data/single_sample.genotype.vcf
@@ -1,0 +1,82 @@
+##fileformat=VCFv4.0
+##source=VarscanSomatic
+##reference=ftp://ftp.ncbi.nih.gov/genbank/genomes/Eukaryotes/vertebrates_mammals/Homo_sapiens/GRCh37/special_requests/GRCh37-lite.fa.gz
+##phasing=none
+##center=genome.wustl.edu
+##FILTER=<ID=PASS,Description="Passed all filters">
+##FILTER=<ID=VarscanHighConfidenceIndel,Description="Filter description">
+##FORMAT=<ID=DP4,Number=4,Type=Integer,Description="Number of high-quality ref-forward, ref-reverse, alt-forward and alt-reverse bases">
+##FORMAT=<ID=BQ,Number=.,Type=Integer,Description="Average base quality for reads supporting alleles">
+##FORMAT=<ID=SS,Number=1,Type=Integer,Description="Variant status relative to non-adjacent Normal,0=wildtype,1=germline,2=somatic,3=LOH,4=post-transcriptional modification,5=unknown">
+##FORMAT=<ID=GQ,Number=.,Type=Integer,Description="Conditional Phred-scaled genotype quality">
+##FORMAT=<ID=MQ,Number=1,Type=Integer,Description="Phred style probability score that the variant is novel with respect to the genome's ancestor">
+##FORMAT=<ID=FA,Number=1,Type=Float,Description="Fraction of reads supporting ALT">
+##FORMAT=<ID=VAQ,Number=1,Type=Integer,Description="Variant allele quality">
+##FORMAT=<ID=FT,Number=1,Type=String,Description="Sample genotype filter">
+##FORMAT=<ID=AMQ,Number=.,Type=Integer,Description="Average mapping quality for each allele present in the genotype">
+##FORMAT=<ID=IGT,Number=1,Type=String,Description="Genotype when called independently (only filled if called in joint prior mode)">
+##FORMAT=<ID=BCOUNT,Number=4,Type=Integer,Description="Occurrence count for each base at this site (A,C,G,T)">
+##FORMAT=<ID=JGQ,Number=1,Type=Integer,Description="Joint genotype quality (only filled if called in join prior mode)">
+##FORMAT=<ID=SSC,Number=1,Type=Integer,Description="Somatic score between 0 and 255">
+##source=Strelka
+##FORMAT=<ID=FDP,Number=1,Type=Integer,Description="Number of basecalls filtered from original read depth for tier1">
+##FORMAT=<ID=SDP,Number=1,Type=Integer,Description="Number of reads with deletions spanning this site at tier1">
+##FORMAT=<ID=SUBDP,Number=1,Type=Integer,Description="Number of reads below tier1 mapping quality threshold aligned across this site">
+##FORMAT=<ID=AU,Number=2,Type=Integer,Description="Number of 'A' alleles used in tiers 1,2">
+##FORMAT=<ID=CU,Number=2,Type=Integer,Description="Number of 'C' alleles used in tiers 1,2">
+##FORMAT=<ID=GU,Number=2,Type=Integer,Description="Number of 'G' alleles used in tiers 1,2">
+##FORMAT=<ID=TU,Number=2,Type=Integer,Description="Number of 'T' alleles used in tiers 1,2">
+##FORMAT=<ID=DP2,Number=1,Type=Integer,Description="Read depth for tier2">
+##FORMAT=<ID=TAR,Number=2,Type=Integer,Description="Reads strongly supporting alternate allele for tiers 1,2">
+##FORMAT=<ID=TIR,Number=2,Type=Integer,Description="Reads strongly supporting indel allele for tiers 1,2">
+##FORMAT=<ID=TOR,Number=2,Type=Integer,Description="Other reads (weak support or insufficient indel breakpoint overlap) for tiers 1,2">
+##FORMAT=<ID=DP50,Number=1,Type=Float,Description="Average tier1 read depth within 50 bases">
+##FORMAT=<ID=FDP50,Number=1,Type=Float,Description="Average tier1 number of basecalls filtered from original read depth within 50 bases">
+##FORMAT=<ID=SUBDP50,Number=1,Type=Float,Description="Average number of reads below tier1 mapping quality threshold aligned across sites within 50 bases">
+##INFO=<ID=QSI,Number=1,Type=Integer,Description="Quality score for any somatic variant, ie. for the ALT haplotype to be present at a significantly different frequency in the tumor and normal">
+##INFO=<ID=TQSI,Number=1,Type=Integer,Description="Data tier used to compute QSI">
+##INFO=<ID=NT,Number=1,Type=String,Description="Genotype of the normal in all data tiers, as used to classify somatic variants. One of {ref,het,hom,conflict}.">
+##INFO=<ID=QSI_NT,Number=1,Type=Integer,Description="Quality score reflecting the joint probability of a somatic variant and NT">
+##INFO=<ID=TQSI_NT,Number=1,Type=Integer,Description="Data tier used to compute QSI_NT">
+##INFO=<ID=SGT,Number=1,Type=String,Description="Most likely somatic genotype excluding normal noise states">
+##INFO=<ID=RU,Number=1,Type=String,Description="Smallest repeating sequence unit in inserted or deleted sequence">
+##INFO=<ID=RC,Number=1,Type=Integer,Description="Number of times RU repeats in the reference allele">
+##INFO=<ID=IC,Number=1,Type=Integer,Description="Number of times RU repeats in the indel allele">
+##INFO=<ID=IHP,Number=1,Type=Integer,Description="Largest reference interupted homopolymer length intersecting with the indel">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=OVERLAP,Number=0,Type=Flag,Description="Somatic indel possibly overlaps a second indel.">
+##FILTER=<ID=DP,Description="Greater than 3.0x chromosomal mean depth in Normal sample">
+##FILTER=<ID=Repeat,Description="Sequence repeat of more than 8x in the reference sequence">
+##FILTER=<ID=iHpol,Description="Indel overlaps an interupted homopolymer longer than 14x in the reference sequence">
+##FILTER=<ID=BCNoise,Description="Average fraction of filtered basecalls within 50 bases of the indel exceeds 0.3">
+##FILTER=<ID=QSI_ref,Description="Normal sample is not homozygous ref or sindel Q-score < 30, ie calls with NT!=ref or QSI_NT < 30">
+##source=Pindel
+##FILTER=<ID=PindelSomaticCalls,Description="Filter description">
+##FILTER=<ID=PindelVafFilter,Description="Filter description">
+##FILTER=<ID=PindelReadSupport,Description="Filter description">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=HOMLEN,Number=.,Type=Integer,Description="Length of base pair identical micro-homology at event breakpoints">
+##INFO=<ID=HOMSEQ,Number=.,Type=String,Description="Sequence of base pair identical micro-homology at event breakpoints">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=NTLEN,Number=.,Type=Integer,Description="Number of bases inserted in place of deleted code">
+##source=GatkSomaticIndel
+##fileDate=20160321
+##INFO=<ID=QSS,Number=1,Type=Integer,Description="Quality score for any somatic snv, ie. for the ALT allele to be present at a significantly different frequency in the tumor and normal">
+##INFO=<ID=TQSS,Number=1,Type=Integer,Description="Data tier used to compute QSS">
+##INFO=<ID=QSS_NT,Number=1,Type=Integer,Description="Quality score reflecting the joint probability of a somatic variant and NT">
+##INFO=<ID=TQSS_NT,Number=1,Type=Integer,Description="Data tier used to compute QSS_NT">
+##FILTER=<ID=VarFilterSnv,Description="Filter description">
+##FILTER=<ID=FalsePositiveVcf,Description="Filter description">
+##FILTER=<ID=FalsePositive,Description="Filter description">
+##FILTER=<ID=SomaticScoreMappingQuality,Description="Filter description">
+##FILTER=<ID=IntersectionFailure,Description="Variant callers do not agree on this position">
+##FILTER=<ID=SpanDel,Description="Fraction of reads crossing site with spanning deletions in either sample exceeeds 0.75">
+##FILTER=<ID=QSS_ref,Description="Normal sample is not homozygous ref or ssnv Q-score < 15, ie calls with NT!=ref or QSS_NT < 15">
+##FORMAT=<ID=TLOD,Number=.,Type=Float,Description="Log of (likelihood tumor event is real / likelihood event is sequencing error)">
+##FILTER=<ID=REJECT,Description="Rejected as a confident somatic mutation by MuTect">
+##FILTER=<ID=VarscanHighConfidence,Description="Filter description">
+##FILTER=<ID=PASS,Description="Passed all filters">
+##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence type as predicted by VEP. Format: Allele|Gene|Feature|Feature_type|Consequence|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|DISTANCE|STRAND|CANONICAL|SYMBOL|SYMBOL_SOURCE|SIFT|PolyPhen|HGVSc|HGVSp|DownstreamProtein|ProteinLengthChange|WildtypeProtein">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	H_NJ-HCC1395-HCC1395	TUMOR
+22	18644673	.	C	T	.	.	CSQ=T|ENSG00000184979|ENST00000215794|Transcript|missense_variant|801|371|124|A/V|gCc/gTc|||||||1|YES|USP18|HGNC|tolerated(1)|benign(0.162)|ENST00000215794.7%3Ac.371C>T|ENSP00000215794.7%3Ap.Ala124Val|||MSKAFGLLRQICQSILAESSQSPADLEEKKEEDSNMKREQPRERPRAWDYPHGLVGLHNIGQTCCLNSLIQVFVMNVDFTRILKRITVPRGADEQRRSVPFQMLLLLEKMQDSRQKAVRPLELAYCLQKCNVPLFVQHDAAQLYLKLWNLIKDQITDVHLVERLQALYTIRVKDSLICVDCAMESSRNSSMLTLPLSLFDVDSKPLKTLEDALHCFFQPRELSSKSKCFCENCGKKTRGKQVLKLTHLPQTLTIHLMRFSIRNSQTRKICHSLYFPQSLDFSQILPMKRESCDAEEQSGGQYELFAVIAHVGMADSGHYCVYIRNAVDGKWFCFNDSNICLVSWEDIQCTYGNPNYHWQETAYLLVYMKMEC	GT:BQ:SS:FDP:SDP:SUBDP:AU:CU:GU:TU:FT:FA:TLOD	0/1:.:2:1:0:0:0,0:106,108:0,0:6,6:PASS:0.04:7.56609	0/1:.:.:.:.:.:.:.:.:.:.:.:.

--- a/tests/test_vcf_genotype_annotator.py
+++ b/tests/test_vcf_genotype_annotator.py
@@ -1,0 +1,51 @@
+import unittest
+import sys
+import os
+import py_compile
+from vatools import vcf_genotype_annotator
+import tempfile
+from filecmp import cmp
+
+class VcfExpressionEncoderTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        base_dir          = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
+        cls.executable    = os.path.join(base_dir, 'vatools', 'vcf_genotype_annotator.py')
+        cls.test_data_dir = os.path.join(base_dir, 'tests', 'test_data')
+
+    def test_source_compiles(self):
+        self.assertTrue(py_compile.compile(self.executable))
+
+    def test_error_sample_name_already_exists(self):
+        with self.assertRaises(Exception) as context:
+            command = [
+                os.path.join(self.test_data_dir, 'input.vcf'),
+                'H_NJ-HCC1395-HCC1395',
+                '0/1',
+            ]
+            vcf_genotype_annotator.main(command)
+        self.assertTrue('VCF already contains a sample column for sample H_NJ-HCC1395-HCC1395.' in str(context.exception))
+
+    def test_no_sample_vcf(self):
+        temp_path = tempfile.TemporaryDirectory()
+        os.symlink(os.path.join(self.test_data_dir, 'input.no_sample.vcf'), os.path.join(temp_path.name, 'input.vcf'))
+        command = [
+            os.path.join(temp_path.name, 'input.vcf'),
+            'TUMOR',
+            '0/1',
+        ]
+        vcf_genotype_annotator.main(command)
+        self.assertTrue(cmp(os.path.join(self.test_data_dir, 'no_sample.genotype.vcf'), os.path.join(temp_path.name, 'input.genotype.vcf')))
+        temp_path.cleanup()
+
+    def test_single_sample_vcf(self):
+        temp_path = tempfile.TemporaryDirectory()
+        os.symlink(os.path.join(self.test_data_dir, 'input.vcf'), os.path.join(temp_path.name, 'input.vcf'))
+        command = [
+            os.path.join(temp_path.name, 'input.vcf'),
+            'TUMOR',
+            '0/1',
+        ]
+        vcf_genotype_annotator.main(command)
+        self.assertTrue(cmp(os.path.join(self.test_data_dir, 'single_sample.genotype.vcf'), os.path.join(temp_path.name, 'input.genotype.vcf')))
+        temp_path.cleanup()

--- a/vatools/vcf_genotype_annotator.py
+++ b/vatools/vcf_genotype_annotator.py
@@ -1,0 +1,79 @@
+import argparse
+import sys
+import vcfpy
+import csv
+from collections import OrderedDict
+
+def create_vcf_reader(args):
+    vcf_reader = vcfpy.Reader.from_path(args.input_vcf)
+    if args.sample_name in vcf_reader.header.samples.names:
+        vcf_reader.close()
+        raise Exception("VCF already contains a sample column for sample {}.".format(args.sample_name))
+    return vcf_reader
+
+def create_vcf_writer(args, vcf_reader):
+    if args.output_vcf:
+        output_file = args.output_vcf
+    else:
+        (head, sep, tail) = args.input_vcf.rpartition('.vcf')
+        output_file = ('').join([head, '.genotype.vcf', tail])
+    sample_info = vcf_reader.header.samples
+    sample_info.names.append(args.sample_name)
+    sample_info.name_to_idx[args.sample_name] = len(sample_info.names)-1
+    new_header = vcfpy.Header(samples = sample_info)
+    for line in vcf_reader.header.lines:
+        if not (line.key == 'FORMAT' and line.id == 'GT'):
+            new_header.add_line(line)
+    new_header.add_format_line(OrderedDict([('ID', 'GT'), ('Number', '1'), ('Type', 'String'), ('Description', 'Genotype')]))
+    return vcfpy.Writer.from_path(output_file, new_header)
+
+def define_parser():
+    parser = argparse.ArgumentParser("vcf-genotype-annotator")
+
+    parser.add_argument(
+        "input_vcf",
+        help="A VCF file"
+    )
+    parser.add_argument(
+        "sample_name",
+        help="The name of the sample to add",
+    )
+    parser.add_argument(
+        "genotype_value",
+        choices=['0/1', '1/1', '0/0', '.'],
+        default='0/1',
+        help="The genotype value to add to the GT field"
+    )
+    parser.add_argument(
+        "-o", "--output-vcf",
+        help="Path to write the output VCF file. If not provided, the output VCF file will be "
+            +"written next to the input VCF file with a .genotype.vcf file ending."
+    )
+    return parser
+
+def main(args_input = sys.argv[1:]):
+    parser = define_parser()
+    args = parser.parse_args(args_input)
+
+    vcf_reader = create_vcf_reader(args)
+    vcf_writer = create_vcf_writer(args, vcf_reader)
+
+    for entry in vcf_reader:
+        new_sample_call = vcfpy.Call(args.sample_name, data={'GT': args.genotype_value})
+        if "GT" not in entry.FORMAT:
+            if isinstance(entry.FORMAT, tuple):
+                entry.FORMAT = ["GT"]
+            else:
+                entry.FORMAT = entry.FORMAT.appened('GT')
+        if entry.calls:
+            entry.calls.append(new_sample_call)
+        else:
+            entry.calls = [new_sample_call]
+        entry.call_for_sample = {call.sample: call for call in entry.calls}
+        vcf_writer.write_record(entry)
+
+    vcf_reader.close()
+    vcf_writer.close()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
pVACseq requires the GT field for the sample being processed. We have users creating manual VCFs, for example, from calls reported in a paper, or wanting to add a normal sample to a tumor-only VCF in order to add readcounts. This tool allows users to add a new sample to their VCF and specifying which genotype to use to fill the GT field.

```
$ vcf-genotype-annotator -h
usage: vcf-genotype-annotator [-h] [-o OUTPUT_VCF]
                              input_vcf sample_name {0/1,1/1,0/0,.}

positional arguments:
  input_vcf             A VCF file
  sample_name           The name of the sample to add
  {0/1,1/1,0/0,.}       The genotype value to add to the GT field

optional arguments:
  -h, --help            show this help message and exit
  -o OUTPUT_VCF, --output-vcf OUTPUT_VCF
                        Path to write the output VCF file. If not provided,
                        the output VCF file will be written next to the input
                        VCF file with a .genotype.vcf file ending.
```